### PR TITLE
iidxhook: Make settings path in settings hook configurable

### DIFF
--- a/dist/iidx/iidxhook-09.conf
+++ b/dist/iidx/iidxhook-09.conf
@@ -52,6 +52,9 @@ misc.disable_clock_set=false
 # Stub calls to rteffect.dll (10th to DistorteD)
 misc.rteffect_stub=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security boot version (e.g. GEC02).
 sec.boot_version=GEC02   
 

--- a/dist/iidx/iidxhook-10.conf
+++ b/dist/iidx/iidxhook-10.conf
@@ -52,6 +52,9 @@ misc.disable_clock_set=false
 # Stub calls to rteffect.dll (10th to DistorteD)
 misc.rteffect_stub=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security boot version (e.g. GEC02).
 sec.boot_version=GEC02   
 

--- a/dist/iidx/iidxhook-11.conf
+++ b/dist/iidx/iidxhook-11.conf
@@ -52,6 +52,9 @@ misc.disable_clock_set=false
 # Stub calls to rteffect.dll (10th to DistorteD)
 misc.rteffect_stub=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security boot version (e.g. GEC02).
 sec.boot_version=GEC02   
 

--- a/dist/iidx/iidxhook-12.conf
+++ b/dist/iidx/iidxhook-12.conf
@@ -55,6 +55,9 @@ misc.disable_clock_set=false
 # Stub calls to rteffect.dll (10th to DistorteD)
 misc.rteffect_stub=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security boot version (e.g. GEC02).
 sec.boot_version=GEC02   
 

--- a/dist/iidx/iidxhook-13.conf
+++ b/dist/iidx/iidxhook-13.conf
@@ -55,6 +55,9 @@ misc.disable_clock_set=false
 # Stub calls to rteffect.dll (10th to DistorteD)
 misc.rteffect_stub=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security boot version (e.g. GEC02).
 sec.boot_version=GEC02   
 

--- a/dist/iidx/iidxhook-14.conf
+++ b/dist/iidx/iidxhook-14.conf
@@ -46,5 +46,8 @@ gfx.device_adapter=-1
 # Disable operator clock setting system clock time
 misc.disable_clock_set=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GQGLDJAA

--- a/dist/iidx/iidxhook-15.conf
+++ b/dist/iidx/iidxhook-15.conf
@@ -46,5 +46,8 @@ gfx.device_adapter=-1
 # Disable operator clock setting system clock time
 misc.disable_clock_set=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GQHDDJAA

--- a/dist/iidx/iidxhook-16.conf
+++ b/dist/iidx/iidxhook-16.conf
@@ -49,5 +49,8 @@ gfx.device_adapter=-1
 # Disable operator clock setting system clock time
 misc.disable_clock_set=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GQI00JAA

--- a/dist/iidx/iidxhook-17.conf
+++ b/dist/iidx/iidxhook-17.conf
@@ -49,5 +49,8 @@ gfx.device_adapter=-1
 # Disable operator clock setting system clock time
 misc.disable_clock_set=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GCJDJJAA

--- a/dist/iidx/iidxhook-18-cn.conf
+++ b/dist/iidx/iidxhook-18-cn.conf
@@ -46,5 +46,8 @@ gfx.diagonal_tearing_fix=false
 # Disable ezusb IO emulation and enable usage of real ezusb1/2 IO hardware
 io.disable_io_emu=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GKJDZCAA

--- a/dist/iidx/iidxhook-18.conf
+++ b/dist/iidx/iidxhook-18.conf
@@ -45,3 +45,6 @@ io.disable_card_reader_emu=false
 
 # Disable ezusb IO emulation and enable usage of real ezusb1/2 IO hardware
 io.disable_io_emu=false
+
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\

--- a/dist/iidx/iidxhook-19.conf
+++ b/dist/iidx/iidxhook-19.conf
@@ -42,3 +42,6 @@ io.disable_card_reader_emu=false
 
 # Disable ezusb IO emulation and enable usage of real ezusb1/2 IO hardware
 io.disable_io_emu=false
+
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\

--- a/dist/iidx/iidxhook-20-cn.conf
+++ b/dist/iidx/iidxhook-20-cn.conf
@@ -43,5 +43,8 @@ gfx.diagonal_tearing_fix=false
 # Disable ezusb IO emulation and enable usage of real ezusb1/2 IO hardware
 io.disable_io_emu=false
 
+# Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data
+misc.settings_path=.\
+
 # Security black plug mcode id string (e.g. GQC02JAA).
 sec.black_plug_mcode=GKJDZCAA

--- a/src/main/iidxhook-util/config-misc.c
+++ b/src/main/iidxhook-util/config-misc.c
@@ -6,9 +6,11 @@
 
 #define IIDXHOOK_CONFIG_MISC_DISABLE_CLOCK_SET_KEY "misc.disable_clock_set"
 #define IIDXHOOK_CONFIG_MISC_RTEFFECT_STUB_KEY "misc.rteffect_stub"
+#define IIDXHOOK_CONFIG_MISC_SETTINGS_PATH_STUB_KEY "misc.settings_path"
 
 #define IIDXHOOK_CONFIG_MISC_DEFAULT_DISABLE_CLOCK_SET_VALUE false
 #define IIDXHOOK_CONFIG_MISC_DEFAULT_RTEFFECT_STUB_VALUE false
+#define IIDXHOOK_CONFIG_MISC_DEFAULT_SETTINGS_PATH_STUB_VALUE ".\\"
 
 void iidxhook_config_misc_init(struct cconfig *config)
 {
@@ -23,6 +25,12 @@ void iidxhook_config_misc_init(struct cconfig *config)
         IIDXHOOK_CONFIG_MISC_RTEFFECT_STUB_KEY,
         IIDXHOOK_CONFIG_MISC_DEFAULT_RTEFFECT_STUB_VALUE,
         "Stub calls to rteffect.dll (10th to DistorteD)");
+
+    cconfig_util_set_str(
+        config,
+        IIDXHOOK_CONFIG_MISC_SETTINGS_PATH_STUB_KEY,
+        IIDXHOOK_CONFIG_MISC_DEFAULT_SETTINGS_PATH_STUB_VALUE,
+        "Path to store the settings, e.g. bookkeeping, operator settings. d:, e: and f: drive configuration/settings data");
 }
 
 void iidxhook_config_misc_get(
@@ -50,5 +58,18 @@ void iidxhook_config_misc_get(
             "to default '%d'",
             IIDXHOOK_CONFIG_MISC_RTEFFECT_STUB_KEY,
             IIDXHOOK_CONFIG_MISC_DEFAULT_RTEFFECT_STUB_VALUE);
+    }
+
+    if (!cconfig_util_get_str(
+            config,
+            IIDXHOOK_CONFIG_MISC_SETTINGS_PATH_STUB_KEY,
+            config_misc->settings_path,
+            sizeof(config_misc->settings_path),
+            IIDXHOOK_CONFIG_MISC_DEFAULT_SETTINGS_PATH_STUB_VALUE)) {
+        log_warning(
+            "Invalid value for key '%s' specified, fallback "
+            "to default '%s'",
+            IIDXHOOK_CONFIG_MISC_SETTINGS_PATH_STUB_KEY,
+            IIDXHOOK_CONFIG_MISC_DEFAULT_SETTINGS_PATH_STUB_VALUE);
     }
 }

--- a/src/main/iidxhook-util/config-misc.h
+++ b/src/main/iidxhook-util/config-misc.h
@@ -1,11 +1,14 @@
 #ifndef IIDXHOOK_CONFIG_MISC_H
 #define IIDXHOOK_CONFIG_MISC_H
 
+#include <windows.h>
+
 #include "cconfig/cconfig.h"
 
 struct iidxhook_config_misc {
     bool disable_clock_set;
     bool rteffect_stub;
+    char settings_path[MAX_PATH];
 };
 
 void iidxhook_config_misc_init(struct cconfig *config);

--- a/src/main/iidxhook-util/settings.c
+++ b/src/main/iidxhook-util/settings.c
@@ -13,6 +13,7 @@
 #include "util/defs.h"
 #include "util/fs.h"
 #include "util/log.h"
+#include "util/mem.h"
 #include "util/str.h"
 
 /* ------------------------------------------------------------------------- */
@@ -32,6 +33,24 @@ static const struct hook_symbol settings_hook_syms[] = {
 };
 
 static bool settings_folders_checked;
+static char settings_path[MAX_PATH] = ".\\";
+
+/* ------------------------------------------------------------------------- */
+
+static void settings_build_new_path(const char* orig_path, char* new_path, size_t new_path_len)
+{
+    size_t settings_path_len;
+
+    settings_path_len = strlen(settings_path);
+
+    log_assert(settings_path_len + strlen(orig_path) < new_path_len);
+
+    strcpy(new_path, settings_path);
+    strcat(new_path, orig_path);
+
+    /* Remove : of drive letter. Multiple \ are fine and handled by windows */
+    new_path[settings_path_len + 1] = '\\';
+}
 
 /* ------------------------------------------------------------------------- */
 
@@ -44,8 +63,8 @@ BOOL WINAPI my_CreateDirectoryA(
         lpPathName[1] == ':') {
         char new_path[MAX_PATH];
 
-        strcpy(new_path, lpPathName);
-        new_path[1] = '\\';
+        settings_build_new_path(lpPathName, new_path, sizeof(new_path));
+
         log_misc("(CreateDir) Remapped settings path %s", new_path);
 
         return real_CreateDirectoryA(new_path, lpSecurityAttributes);
@@ -61,43 +80,88 @@ void settings_hook_init(void)
     hook_table_apply(
         NULL, "kernel32.dll", settings_hook_syms, lengthof(settings_hook_syms));
 
-    log_info("Inserted settings hooks");
+    log_info("Inserted settings hooks, settings path: %s", settings_path);
+}
+
+void settings_hook_set_path(const char* path)
+{    
+    size_t len;
+
+    len = strlen(path);
+
+    log_assert(path > 0);
+    log_assert(len < MAX_PATH);
+
+    strcpy(settings_path, path);
+
+    /* Ensure trailing \\ to allow simple concatinations in hooks */
+    if (settings_path[len - 1] != '\\') {
+        log_assert(len + 1 < MAX_PATH);
+
+        settings_path[len] = '\\';
+        settings_path[len + 1] = '\0';
+    }
+
+    log_info("Settings path: %s", settings_path);
 }
 
 HRESULT
 settings_hook_dispatch_irp(struct irp *irp)
 {
     if (irp->op == IRP_OP_OPEN &&
-        (irp->open_filename[0] == L'd' || irp->open_filename[0] == L'e' ||
-         irp->open_filename[0] == L'f') &&
-        irp->open_filename[1] == L':') {
-        char *log_str;
+            (irp->open_filename[0] == L'd' || irp->open_filename[0] == L'e' ||
+            irp->open_filename[0] == L'f') &&
+            irp->open_filename[1] == L':') {
+        HRESULT result;
+        char new_path[MAX_PATH];
+        const wchar_t *old_filename_wstr;
+        wchar_t *filename_wstr;
+        char *filename_cstr;
 
-        ((wchar_t *) irp->open_filename)[1] = L'\\';
+        log_assert(wstr_narrow(irp->open_filename, &filename_cstr));
 
-        wstr_narrow(irp->open_filename, &log_str);
-        log_misc("Remapped settings path %s", log_str);
-        free(log_str);
+        settings_build_new_path(filename_cstr, new_path, sizeof(new_path));
 
-        /* Create local settings folders if not available */
+        free(filename_cstr);
+
+        log_misc("Remapped settings path to %s", new_path);
+
+        filename_wstr = str_widen(new_path);
+
+        /* Temporarily swap open_filename */
+        old_filename_wstr = irp->open_filename;
+        irp->open_filename = filename_wstr;
+
+        /* Create settings folders if not available */
         if (!settings_folders_checked) {
             settings_folders_checked = true;
 
             for (char c = 'd'; c <= 'f'; c++) {
-                char str[3];
+                char new_path_folder[MAX_PATH];
+                size_t settings_path_len = strlen(settings_path);
 
-                str[0] = c;
-                str[1] = '\\';
-                str[2] = '\0';
+                log_assert(settings_path_len + 3 < MAX_PATH);
 
-                if (!path_exists(str)) {
-                    log_misc("Creating local settings folder %s\\", str);
-                    CreateDirectoryA(str, NULL);
+                strcpy(new_path_folder, settings_path);
+
+                new_path_folder[settings_path_len] = c;
+                new_path_folder[settings_path_len + 1] = '\\';
+                new_path_folder[settings_path_len + 2] = '\0';
+
+                if (!path_exists(new_path_folder)) {
+                    log_misc("Creating local settings folder %s", new_path_folder);
+                    CreateDirectoryA(new_path_folder, NULL);
                 }
             }
         }
 
-        return iohook_invoke_next(irp);
+        result = iohook_invoke_next(irp);
+
+        /* Revert to original irp */
+        irp->open_filename = old_filename_wstr;
+        free(filename_wstr);
+
+        return result;
     }
 
     return iohook_invoke_next(irp);

--- a/src/main/iidxhook-util/settings.h
+++ b/src/main/iidxhook-util/settings.h
@@ -4,11 +4,20 @@
 #include "hook/iohook.h"
 
 /**
- * Remaps the paths for the settings drives d:\, e:\ and f:\
- * to local folders e\ and f\.
- * Needed on IIDX 9th to Sirius.
+ * Remaps the paths for storing "settings data" that are usually stored on the
+ * drives d:\, e:\ and f:\ by the game. This defaults to the local folders
+ * d\, e\ and f\.
+ * 
+ * Required hook for 9th to Lincle.
  */
 void settings_hook_init(void);
+
+/**
+ * Change the path where settings file are stored.
+ * 
+ * @param path Destination path for storage, relative or absolute.
+ */
+void settings_hook_set_path(const char* path);
 
 /**
  * iohook dispatch function

--- a/src/main/iidxhook1/dllmain.c
+++ b/src/main/iidxhook1/dllmain.c
@@ -191,6 +191,12 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
         effector_hook_init();
     }
 
+    /* Settings paths */
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
+
     /* Direct3D and USER32 hooks */
 
     iidxhook1_setup_d3d9_hooks(&config_gfx, &config_iidxhook1);

--- a/src/main/iidxhook2/dllmain.c
+++ b/src/main/iidxhook2/dllmain.c
@@ -184,6 +184,12 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
         effector_hook_init();
     }
 
+    /* Settings paths */
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
+
     /* Direct3D and USER32 hooks */
 
     iidxhook2_setup_d3d9_hooks(&config_gfx, &config_iidxhook2);

--- a/src/main/iidxhook3/dllmain.c
+++ b/src/main/iidxhook3/dllmain.c
@@ -181,6 +181,12 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
     eamuse_set_addr(&config_eamuse.server);
     eamuse_check_connection();
 
+    /* Settings paths */
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
+
     /* Direct3D and USER32 hooks */
 
     iidxhook3_setup_d3d9_hooks(&config_gfx);

--- a/src/main/iidxhook4-cn/dllmain.c
+++ b/src/main/iidxhook4-cn/dllmain.c
@@ -29,6 +29,7 @@
 #include "iidxhook-util/config-gfx.h"
 #include "iidxhook-util/config-io.h"
 #include "iidxhook-util/config-sec.h"
+#include "iidxhook-util/config-misc.h"
 #include "iidxhook-util/d3d9.h"
 #include "iidxhook-util/settings.h"
 
@@ -117,6 +118,7 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
     struct iidxhook_util_config_eamuse config_eamuse;
     struct iidxhook_config_gfx config_gfx;
     struct iidxhook_config_sec config_sec;
+    struct iidxhook_config_misc config_misc;
 
     if (iidxhook_init_check) {
         return real_OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId);
@@ -134,6 +136,7 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
     iidxhook_config_gfx_init(config);
     iidxhook_config_io_init(config);
     iidxhook_config_sec_init(config);
+    iidxhook_config_misc_init(config);
 
     if (!cconfig_hook_config_init(
             config,
@@ -147,6 +150,7 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
     iidxhook_config_gfx_get(&config_gfx, config);
     iidxhook_config_io_get(&config_io, config);
     iidxhook_config_sec_get(&config_sec, config);
+    iidxhook_config_misc_get(&config_misc, config);
 
     cconfig_finit(config);
 
@@ -168,6 +172,10 @@ my_OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
     ezusb_iidx_emu_node_security_plug_set_pcbid(&config_eamuse.pcbid);
 
     iidxhook4_cn_setup_d3d9_hooks(&config_gfx);
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
 
     if (!config_io.disable_io_emu) {
         log_info("Starting IIDX IO backend");

--- a/src/main/iidxhook4/dllmain.c
+++ b/src/main/iidxhook4/dllmain.c
@@ -29,6 +29,7 @@
 #include "iidxhook-util/chart-patch.h"
 #include "iidxhook-util/config-gfx.h"
 #include "iidxhook-util/config-io.h"
+#include "iidxhook-util/config-misc.h"
 #include "iidxhook-util/d3d9.h"
 #include "iidxhook-util/log-server.h"
 #include "iidxhook-util/settings.h"
@@ -100,6 +101,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
     struct cconfig *config;
 
     struct iidxhook_config_gfx config_gfx;
+    struct iidxhook_config_misc config_misc;
 
     log_server_init();
     log_info("-------------------------------------------------------------");
@@ -110,6 +112,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
 
     iidxhook_config_gfx_init(config);
     iidxhook_config_io_init(config);
+    iidxhook_config_misc_init(config);
 
     if (!cconfig_hook_config_init(
             config,
@@ -122,6 +125,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
 
     iidxhook_config_gfx_get(&config_gfx, config);
     iidxhook_config_io_get(&config_io, config);
+    iidxhook_config_misc_get(&config_misc, config);
 
     cconfig_finit(config);
 
@@ -129,6 +133,10 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
     log_info("Initializing iidxhook...");
 
     iidxhook4_setup_d3d9_hooks(&config_gfx);
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
 
     if (!config_io.disable_io_emu) {
         log_info("Starting IIDX IO backend");

--- a/src/main/iidxhook5-cn/dllmain.c
+++ b/src/main/iidxhook5-cn/dllmain.c
@@ -29,6 +29,7 @@
 #include "iidxhook-util/config-gfx.h"
 #include "iidxhook-util/config-io.h"
 #include "iidxhook-util/config-sec.h"
+#include "iidxhook-util/config-misc.h"
 #include "iidxhook-util/d3d9.h"
 #include "iidxhook-util/settings.h"
 
@@ -98,6 +99,7 @@ static ATOM WINAPI my_RegisterClassA(const WNDCLASSA *lpWndClass)
     struct iidxhook_util_config_eamuse config_eamuse;
     struct iidxhook_config_gfx config_gfx;
     struct iidxhook_config_sec config_sec;
+    struct iidxhook_config_misc config_misc;
 
     if (iidxhook_init_check) {
         return real_RegisterClassA(lpWndClass);
@@ -115,6 +117,7 @@ static ATOM WINAPI my_RegisterClassA(const WNDCLASSA *lpWndClass)
     iidxhook_config_gfx_init(config);
     iidxhook_config_io_init(config);
     iidxhook_config_sec_init(config);
+    iidxhook_config_misc_init(config);
 
     if (!cconfig_hook_config_init(
             config,
@@ -128,6 +131,7 @@ static ATOM WINAPI my_RegisterClassA(const WNDCLASSA *lpWndClass)
     iidxhook_config_gfx_get(&config_gfx, config);
     iidxhook_config_io_get(&config_io, config);
     iidxhook_config_sec_get(&config_sec, config);
+    iidxhook_config_misc_get(&config_misc, config);
 
     cconfig_finit(config);
 
@@ -149,6 +153,10 @@ static ATOM WINAPI my_RegisterClassA(const WNDCLASSA *lpWndClass)
     ezusb_iidx_emu_node_security_plug_set_pcbid(&config_eamuse.pcbid);
 
     iidxhook5_cn_setup_d3d9_hooks(&config_gfx);
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
 
     if (!config_io.disable_io_emu) {
         log_info("Starting IIDX IO backend");

--- a/src/main/iidxhook5/dllmain.c
+++ b/src/main/iidxhook5/dllmain.c
@@ -28,6 +28,7 @@
 #include "iidxhook-util/acio.h"
 #include "iidxhook-util/config-gfx.h"
 #include "iidxhook-util/config-io.h"
+#include "iidxhook-util/config-misc.h"
 #include "iidxhook-util/d3d9.h"
 #include "iidxhook-util/log-server.h"
 #include "iidxhook-util/settings.h"
@@ -82,6 +83,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
     struct cconfig *config;
 
     struct iidxhook_config_gfx config_gfx;
+    struct iidxhook_config_misc config_misc;
 
     log_server_init();
     log_info("-------------------------------------------------------------");
@@ -92,6 +94,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
 
     iidxhook_config_gfx_init(config);
     iidxhook_config_io_init(config);
+    iidxhook_config_misc_init(config);
 
     if (!cconfig_hook_config_init(
             config,
@@ -104,6 +107,7 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
 
     iidxhook_config_gfx_get(&config_gfx, config);
     iidxhook_config_io_get(&config_io, config);
+    iidxhook_config_misc_get(&config_misc, config);
 
     cconfig_finit(config);
 
@@ -111,6 +115,10 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
     log_info("Initializing iidxhook...");
 
     iidxhook5_setup_d3d9_hooks(&config_gfx);
+
+    if (strlen(config_misc.settings_path) > 0) {
+        settings_hook_set_path(config_misc.settings_path);
+    }
 
     if (!config_io.disable_io_emu) {
         log_info("Starting IIDX IO backend");


### PR DESCRIPTION
Additional flexibility to cover use-cases like storing this
data on a separate partition which keeps the game data folder
clean and read-only.