### PR TITLE
IIDX 25/26 - Add the ability to leave a camera unassigned

### DIFF
--- a/dist/iidx/iidxhook-25.conf
+++ b/dist/iidx/iidxhook-25.conf
@@ -46,7 +46,7 @@ cam.disable_camera2=false
 # Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id1=
 
-# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
+# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id2=
 
 # Disable card reader emulation and enable usage of real card reader hardware on COM1 (for games supporting slotted readers)

--- a/dist/iidx/iidxhook-25.conf
+++ b/dist/iidx/iidxhook-25.conf
@@ -43,7 +43,7 @@ cam.disable_camera1=false
 # Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
 cam.disable_camera2=false
 
-# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
+# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id1=
 
 # Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned

--- a/dist/iidx/iidxhook-25.conf
+++ b/dist/iidx/iidxhook-25.conf
@@ -37,10 +37,10 @@ gfx.device_adapter=-1
 # Disables the camera emulation
 cam.disable_emu=false
 
-# Override camera device ID 1 detection (copy from device manager, do not escape)
+# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id1=
 
-# Override camera device ID 2 detection (copy from device manager, do not escape)
+# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id2=
 
 # Disable card reader emulation and enable usage of real card reader hardware on COM1 (for games supporting slotted readers)

--- a/dist/iidx/iidxhook-25.conf
+++ b/dist/iidx/iidxhook-25.conf
@@ -37,6 +37,12 @@ gfx.device_adapter=-1
 # Disables the camera emulation
 cam.disable_emu=false
 
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=false
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
+
 # Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id1=
 

--- a/dist/iidx/iidxhook-26.conf
+++ b/dist/iidx/iidxhook-26.conf
@@ -46,7 +46,7 @@ cam.disable_camera2=false
 # Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id1=
 
-# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
+# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id2=
 
 # Disable card reader emulation and enable usage of real card reader hardware on COM1 (for games supporting slotted readers)

--- a/dist/iidx/iidxhook-26.conf
+++ b/dist/iidx/iidxhook-26.conf
@@ -43,7 +43,7 @@ cam.disable_camera1=false
 # Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
 cam.disable_camera2=false
 
-# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
+# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect
 cam.device_id1=
 
 # Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned

--- a/dist/iidx/iidxhook-26.conf
+++ b/dist/iidx/iidxhook-26.conf
@@ -37,10 +37,10 @@ gfx.device_adapter=-1
 # Disables the camera emulation
 cam.disable_emu=false
 
-# Override camera device ID 1 detection (copy from device manager, do not escape)
+# Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id1=
 
-# Override camera device ID 2 detection (copy from device manager, do not escape)
+# Override camera device ID 2 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id2=
 
 # Disable card reader emulation and enable usage of real card reader hardware on COM1 (for games supporting slotted readers)

--- a/dist/iidx/iidxhook-26.conf
+++ b/dist/iidx/iidxhook-26.conf
@@ -37,6 +37,12 @@ gfx.device_adapter=-1
 # Disables the camera emulation
 cam.disable_emu=false
 
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=true
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
+
 # Override camera device ID 1 detection (copy from device manager, do not escape) Leave blank to automatically detect, or set to SKIP (case sensitive) to leave this camera unassigned
 cam.device_id1=
 

--- a/dist/iidx/iidxhook-26.conf
+++ b/dist/iidx/iidxhook-26.conf
@@ -38,7 +38,7 @@ gfx.device_adapter=-1
 cam.disable_emu=false
 
 # Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
-cam.disable_camera1=true
+cam.disable_camera1=false
 
 # Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
 cam.disable_camera2=false

--- a/dist/iidx/iidxhook-27.conf
+++ b/dist/iidx/iidxhook-27.conf
@@ -20,7 +20,13 @@ io.disable_file_hooks=false
 io.tt_multiplier=1.0
 
 # Disables the camera emulation
-cam.disable_emu=false
+cam.disable_emu=true
+
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=false
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
 
 # Override camera device ID detection (copy from device manager, do not escape)
 cam.device_id1=

--- a/dist/iidx/iidxhook-28.conf
+++ b/dist/iidx/iidxhook-28.conf
@@ -22,6 +22,12 @@ io.tt_multiplier=1.0
 # Disables the camera emulation
 cam.disable_emu=true
 
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=false
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
+
 # Override camera device ID detection (copy from device manager, do not escape)
 cam.device_id1=
 

--- a/dist/iidx/iidxhook-29.conf
+++ b/dist/iidx/iidxhook-29.conf
@@ -22,6 +22,12 @@ io.tt_multiplier=1.0
 # Disables the camera emulation
 cam.disable_emu=true
 
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=true
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
+
 # Override camera device ID detection (copy from device manager, do not escape)
 cam.device_id1=
 

--- a/src/main/camhook/cam.c
+++ b/src/main/camhook/cam.c
@@ -706,6 +706,11 @@ void fill_cam_struct(struct CameraData *data, const char *devid)
         // Device instance path
         strcpy(data->deviceInstancePath, devid);
         // continue
+    } else if (check_four(devid, "SKIP")) {
+        // User wants to leave this camera unassigned
+        num_addressed_cams++;
+        num_located_cams++;
+        return;
     } else {
         // UNKNOWN ENTRY
         log_info("UNK: %s", devid);

--- a/src/main/camhook/config-cam.c
+++ b/src/main/camhook/config-cam.c
@@ -7,8 +7,18 @@
 #define CAMHOOK_CONFIG_CAM_DISABLE_EMU_KEY "cam.disable_emu"
 #define CAMHOOK_CONFIG_CAM_DEFAULT_DISABLE_EMU_VALUE false
 
-// the following two arrays are based on CAMHOOK_CONFIG_CAM_MAX
+// the following four arrays are based on CAMHOOK_CONFIG_CAM_MAX
 // please insert more elements if more cams are added
+const char *camhook_config_disable_camera[CAMHOOK_CONFIG_CAM_MAX] = {
+    "cam.disable_camera1",
+    "cam.disable_camera2",
+};
+
+const int camhook_config_disable_camera_default_values[CAMHOOK_CONFIG_CAM_MAX] = {
+    false,
+    false,
+};
+
 const char *camhook_config_device_id_keys[CAMHOOK_CONFIG_CAM_MAX] = {
     "cam.device_id1",
     "cam.device_id2",
@@ -28,6 +38,11 @@ void camhook_config_cam_init(struct cconfig *config, size_t num_cams)
         "Disables the camera emulation");
 
     for (size_t i = 0; i < num_cams; ++i) {
+        cconfig_util_set_bool(
+            config,
+            camhook_config_disable_camera[i],
+            camhook_config_disable_camera_default_values[i],
+            "Disable camera");
         cconfig_util_set_str(
             config,
             camhook_config_device_id_keys[i],
@@ -56,17 +71,28 @@ void camhook_config_cam_get(
             CAMHOOK_CONFIG_CAM_DEFAULT_DISABLE_EMU_VALUE);
     }
     for (size_t i = 0; i < num_cams; ++i) {
-        if (!cconfig_util_get_str(
+        if (!cconfig_util_get_bool(
                 config,
-                camhook_config_device_id_keys[i],
-                config_cam->device_id[i],
-                sizeof(config_cam->device_id[i]) - 1,
-                camhook_config_device_default_values[i])) {
+                camhook_config_disable_camera[i],
+                &config_cam->disable_camera[i],
+                camhook_config_disable_camera_default_values[i])) {
             log_warning(
                 "Invalid value for key '%s' specified, fallback "
-                "to default '%s'",
-                camhook_config_device_id_keys[i],
-                camhook_config_device_default_values[i]);
+                "to default '%d'",
+                camhook_config_disable_camera[i],
+                camhook_config_disable_camera_default_values[i]);
+        }
+        if (!cconfig_util_get_str(
+            config,
+            camhook_config_device_id_keys[i],
+            config_cam->device_id[i],
+            sizeof(config_cam->device_id[i]) - 1,
+            camhook_config_device_default_values[i])) {
+        log_warning(
+            "Invalid value for key '%s' specified, fallback "
+            "to default '%s'",
+            camhook_config_device_id_keys[i],
+            camhook_config_device_default_values[i]);
         }
     }
 }

--- a/src/main/camhook/config-cam.h
+++ b/src/main/camhook/config-cam.h
@@ -11,6 +11,7 @@ struct camhook_config_cam {
     bool disable_emu;
     size_t num_devices;
     char device_id[CAMHOOK_CONFIG_CAM_MAX][MAX_PATH];
+    bool disable_camera[CAMHOOK_CONFIG_CAM_MAX];
 };
 
 void camhook_config_cam_init(struct cconfig *config, size_t num_cams);


### PR DESCRIPTION
By setting the custom camera device override in iidxhook.conf to SKIP, bemanitools will now leave that camera unassigned. This is particularly useful for leaving camera 1 unassigned and letting bemanitools automatically map camera 2; most people have their webcams pointed at their face, and camera 2 corresponds to the face cam ingame whereas camera 1 is the hand cam. Also if someone for some reason wanted to use the QR scanning function, that goes through camera 2, so someone with only one camera would have been completely unable to use that.