### PR TITLE
Fix link to bemanitools-supplement in README.md to point to github instead of s-ul

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Depending on the game, you also need the following dependencies installed:
 * The [DirectX 9 End-User Runtimes (June 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=8109)
 
 See also
-[bemanitools-supplements](https://dev.s-ul.net/djhackers/bemanitools-supplement/-/blob/master/misc/win-runtime/README.md)
+[bemanitools-supplement](https://www.github.com/djhackersdev/bemanitools-supplement/)
 for files.
 
 ## Development


### PR DESCRIPTION
I made an issue for this, #241, but I figured might as well do it myself since I've already got it forked >_>

Resolves #241 