### PR TITLE
launcher: print build info at startup

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,6 +37,8 @@ ldflags		          := -Wl,--gc-sections -static-libgcc
 
 all: build
 
+FORCE:
+
 .PHONY: \
 build-docker \
 clean \
@@ -44,7 +46,8 @@ code-format \
 print-building \
 print-release \
 run-tests \
-version
+version \
+FORCE
 
 release: \
 print-release \
@@ -192,6 +195,8 @@ $$(depdir_$1_$2_$3):
 
 $$(objdir_$1_$2_$3):
 	$(V)mkdir -p $$@
+
+$$(volatile_$3:%.c=$$(objdir_$1_$2_$3)/%.o): FORCE
 
 $$(objdir_$1_$2_$3)/%.o: $$(srcdir_$3)/%.c \
 		| $$(depdir_$1_$2_$3) $$(objdir_$1_$2_$3)

--- a/src/main/inject/Module.mk
+++ b/src/main/inject/Module.mk
@@ -13,3 +13,7 @@ src_inject      := \
     logger.c \
     options.c \
     version.c \
+
+volatile_inject := \
+    version.c \
+

--- a/src/main/launcher/Module.mk
+++ b/src/main/launcher/Module.mk
@@ -20,4 +20,8 @@ src_launcher    := \
     options.c \
     property.c \
     stubs.c \
+    version.c \
+
+volatile_launcher := \
+    version.c \
 

--- a/src/main/launcher/main.c
+++ b/src/main/launcher/main.c
@@ -14,6 +14,7 @@
 #include "launcher/options.h"
 #include "launcher/property.h"
 #include "launcher/stubs.h"
+#include "launcher/version.h"
 
 #include "util/codepage.h"
 #include "util/defs.h"
@@ -139,6 +140,10 @@ int main(int argc, const char **argv)
     struct property_node *ea3_config_root;
 
     log_to_writer(log_writer_file, stdout);
+    log_info(
+        "launcher build date %s, gitrev %s",
+        launcher_build_date,
+        launcher_gitrev);
 
     /* Read command line */
 

--- a/src/main/launcher/version.c
+++ b/src/main/launcher/version.c
@@ -1,0 +1,4 @@
+#include "util/defs.h"
+
+const char *launcher_build_date = __DATE__ " " __TIME__;
+const char *launcher_gitrev = STRINGIFY(GITREV);

--- a/src/main/launcher/version.h
+++ b/src/main/launcher/version.h
@@ -1,0 +1,4 @@
+#pragma once
+
+extern const char *launcher_build_date;
+extern const char *launcher_gitrev;


### PR DESCRIPTION
Following the same pattern as `inject` and some hooks, useful for when getting debug logs.

One worry I have, same as when used elsewhere, is that version.c doesn't get rebuilt every build, allowing it to become stale. Does the Makefile system allow specifying a force-rebuild target?