### PR TITLE
Implement ea3-ident.xml overrides

### DIFF
--- a/src/imports/avs.h
+++ b/src/imports/avs.h
@@ -203,8 +203,8 @@ int property_psmap_export(
     const struct property_psmap *psmap);
 
 struct property_node *property_node_clone(
-    struct property *new_parent,
-    int unk0,
+    struct property *parent_prop,
+    struct property_node *parent_node,
     struct property_node *src,
     bool deep);
 struct property_node *property_node_create(

--- a/src/imports/import_32_1101_avs.def
+++ b/src/imports/import_32_1101_avs.def
@@ -21,6 +21,8 @@ EXPORTS
     property_node_datasize @267 NONAME
     property_node_refer @278 NONAME
     property_node_remove @279 NONAME
+    property_node_clone @280 NONAME
+    property_node_traversal @282 NONAME
     property_psmap_import @288 NONAME
     property_psmap_export @287 NONAME
     property_read_query_memsize @291 NONAME

--- a/src/imports/import_32_1304_avs.def
+++ b/src/imports/import_32_1304_avs.def
@@ -21,6 +21,8 @@ EXPORTS
     property_node_datasize @249 NONAME
     property_node_refer @268 NONAME
     property_node_remove @129 NONAME
+    property_node_clone @130 NONAME
+    property_node_traversal @132 NONAME
     property_psmap_import @102 NONAME
     property_psmap_export @110 NONAME
     property_read_query_memsize @100 NONAME

--- a/src/imports/import_32_1403_avs.def
+++ b/src/imports/import_32_1403_avs.def
@@ -16,6 +16,8 @@ EXPORTS
     property_destroy @130 NONAME
     property_insert_read @133 NONAME
     property_node_remove @148 NONAME
+    property_node_clone @149 NONAME
+    property_node_traversal @151 NONAME
     property_psmap_import @163 NONAME
     property_psmap_export @164 NONAME
     property_read_query_memsize @161 NONAME

--- a/src/imports/import_32_1508_avs.def
+++ b/src/imports/import_32_1508_avs.def
@@ -24,6 +24,8 @@ EXPORTS
     property_node_create @145 NONAME
     property_node_refer @158 NONAME
     property_node_remove @146 NONAME
+    property_node_clone @147 NONAME
+    property_node_traversal @149 NONAME
     property_psmap_export @162 NONAME
     property_psmap_import @161 NONAME
     property_read_query_memsize @159 NONAME

--- a/src/imports/import_32_1601_avs.def
+++ b/src/imports/import_32_1601_avs.def
@@ -13,6 +13,8 @@ EXPORTS
     property_search @141 NONAME
     property_node_create @142 NONAME
     property_node_remove @143 NONAME
+    property_node_clone @144 NONAME
+    property_node_traversal @146 NONAME
     property_node_refer @155 NONAME
     property_read_query_memsize @156 NONAME
     property_psmap_export @159 NONAME

--- a/src/imports/import_32_1603_avs.def
+++ b/src/imports/import_32_1603_avs.def
@@ -13,6 +13,8 @@ EXPORTS
     property_search @162 NONAME
     property_node_create @163 NONAME
     property_node_remove @164 NONAME
+    property_node_clone @165 NONAME
+    property_node_traversal @167 NONAME
     property_node_refer @176 NONAME
     property_read_query_memsize @177 NONAME
     property_psmap_import @179 NONAME

--- a/src/imports/import_32_1700_avs.def
+++ b/src/imports/import_32_1700_avs.def
@@ -15,6 +15,8 @@ EXPORTS
     property_search @162 NONAME
     property_node_create @163 NONAME
     property_node_remove @164 NONAME
+    property_node_clone @165 NONAME
+    property_node_traversal @167 NONAME
     property_node_refer @176 NONAME
     property_read_query_memsize @177 NONAME
     property_psmap_import @179 NONAME

--- a/src/imports/import_64_1508_avs.def
+++ b/src/imports/import_64_1508_avs.def
@@ -24,6 +24,8 @@ EXPORTS
     property_node_create @145 NONAME
     property_node_refer @158 NONAME
     property_node_remove @146 NONAME
+    property_node_clone @147 NONAME
+    property_node_traversal @149 NONAME
     property_psmap_export @162 NONAME
     property_psmap_import @161 NONAME
     property_read_query_memsize @159 NONAME

--- a/src/imports/import_64_1509_avs.def
+++ b/src/imports/import_64_1509_avs.def
@@ -24,6 +24,8 @@ EXPORTS
     property_node_create @145 NONAME
     property_node_refer @158 NONAME
     property_node_remove @146 NONAME
+    property_node_clone @147 NONAME
+    property_node_traversal @149 NONAME
     property_psmap_export @162 NONAME
     property_psmap_import @161 NONAME
     property_read_query_memsize @159 NONAME

--- a/src/imports/import_64_1601_avs.def
+++ b/src/imports/import_64_1601_avs.def
@@ -13,6 +13,8 @@ EXPORTS
     property_search @141 NONAME
     property_node_create @142 NONAME
     property_node_remove @143 NONAME
+    property_node_clone @144 NONAME
+    property_node_traversal @146 NONAME
     property_node_refer @155 NONAME
     property_read_query_memsize @156 NONAME
     property_psmap_export @159 NONAME

--- a/src/imports/import_64_1603_avs.def
+++ b/src/imports/import_64_1603_avs.def
@@ -13,6 +13,8 @@ EXPORTS
     property_search @162 NONAME
     property_node_create @163 NONAME
     property_node_remove @164 NONAME
+    property_node_clone @165 NONAME
+    property_node_traversal @167 NONAME
     property_node_refer @176 NONAME
     property_read_query_memsize @177 NONAME
     property_psmap_import @179 NONAME

--- a/src/imports/import_64_1700_avs.def
+++ b/src/imports/import_64_1700_avs.def
@@ -15,6 +15,8 @@ EXPORTS
     property_search @162 NONAME
     property_node_create @163 NONAME
     property_node_remove @164 NONAME
+    property_node_clone @165 NONAME
+    property_node_traversal @167 NONAME
     property_node_refer @176 NONAME
     property_read_query_memsize @177 NONAME
     property_psmap_import @179 NONAME

--- a/src/main/launcher/main.c
+++ b/src/main/launcher/main.c
@@ -238,6 +238,23 @@ int main(int argc, const char **argv)
         log_fatal("%s: /ea3 missing", options.ea3_config_path);
     }
 
+    if (path_exists(options.ea3_ident_path)) {
+        log_info("%s: loading override", options.ea3_ident_path);
+        struct property *ea3_ident = boot_property_load(options.ea3_ident_path);
+        struct property_node *node =
+            property_search(ea3_ident, NULL, "/ea3_conf");
+        if (node == NULL) {
+            log_fatal("%s: /ea3_conf missing", options.ea3_ident_path);
+        }
+
+        for (node = property_node_traversal(node, TRAVERSE_FIRST_CHILD); node;
+             node = property_node_traversal(node, TRAVERSE_NEXT_SIBLING)) {
+            property_node_clone(NULL, ea3_config_root, node, TRUE);
+        }
+
+        boot_property_free(ea3_ident);
+    }
+
     ea3_ident_init(&ea3);
 
     if (!ea3_ident_from_property(&ea3, ea3_config)) {

--- a/src/main/launcher/options.c
+++ b/src/main/launcher/options.c
@@ -19,6 +19,7 @@ void options_init(struct options *options)
     options->app_config_path = "prop/app-config.xml";
     options->avs_config_path = "prop/avs-config.xml";
     options->ea3_config_path = "prop/ea3-config.xml";
+    options->ea3_ident_path = "prop/ea3-ident.xml";
     options->softid = NULL;
     options->pcbid = NULL;
     options->module = NULL;

--- a/src/main/launcher/options.h
+++ b/src/main/launcher/options.h
@@ -12,6 +12,7 @@ struct options {
     const char *app_config_path;
     const char *avs_config_path;
     const char *ea3_config_path;
+    const char *ea3_ident_path;
     const char *softid;
     const char *pcbid;
     const char *module;


### PR DESCRIPTION
This patchset implements support for overriding the EA3 config using `prop/ea3-ident.xml`, a method already in use by alternative tools. It generalizes the approach so that *any* node is picked up and merged with the EA3 config instead of just `<soft>` and `<id>` for future expansion.