### PR TITLE
P3IO emu bugfix, fixes ddrhook1 crashing on startup

### DIFF
--- a/src/main/p3io/cmd.c
+++ b/src/main/p3io/cmd.c
@@ -41,7 +41,7 @@ void p3io_resp_hdr_init(
 {
     log_assert(resp_hdr != NULL);
     log_assert(req_hdr != NULL);
-    log_assert(nbytes < P3IO_MAX_MESSAGE_SIZE);
+    log_assert(nbytes <= P3IO_MAX_MESSAGE_SIZE);
 
     /* Length byte in this packet format counts everything from the length
        byte onwards. The length byte itself occurs at the start of the frame. */

--- a/src/main/p3io/cmd.h
+++ b/src/main/p3io/cmd.h
@@ -161,6 +161,11 @@ struct p3io_req_rs232_write {
     uint8_t bytes[128];
 };
 
+struct p3io_req_unknown_generic {
+    struct p3io_hdr hdr;
+    uint8_t unknown;
+};
+
 struct p3io_req_raw {
     uint8_t data[P3IO_MAX_MESSAGE_SIZE];
 };
@@ -182,6 +187,7 @@ union p3io_req_any {
     struct p3io_req_rs232_open_close rs232_open_close;
     struct p3io_req_rs232_read rs232_read;
     struct p3io_req_rs232_write rs232_write;
+    struct p3io_req_unknown_generic unknown_generic;
     struct p3io_req_raw raw;
 };
 
@@ -266,6 +272,11 @@ struct p3io_resp_rs232_write {
     uint8_t nbytes;
 };
 
+struct p3io_resp_unknown_generic {
+    struct p3io_hdr hdr;
+    uint8_t unknown;
+};
+
 struct p3io_resp_raw {
     uint8_t data[P3IO_MAX_MESSAGE_SIZE];
 };
@@ -286,6 +297,7 @@ union p3io_resp_any {
     struct p3io_resp_rs232_open_close rs232_open_close;
     struct p3io_resp_rs232_read rs232_read;
     struct p3io_resp_rs232_write rs232_write;
+    struct p3io_resp_unknown_generic unknown_generic;
     struct p3io_resp_raw raw;
 };
 


### PR DESCRIPTION
Related issue: #270

Using ddrhook1, this caused DDR X to crash on startup when the
P3io client sends the currently unknown command 2B. Handling it
with the incorrect p3io command struct, any following reading
attempts from the P3IO by the game fail.

Handle the 2B case explicitly with a generic response that worked
previously before the restructuring of the code. Apply the same
to any further unknown commands with improved logging warning
about this.