### PR TITLE
fix(hook): Add missing hook_table_revert impl

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -710,6 +710,8 @@ $(zipdir)/ddr-14-to-18.zip: \
 		build/bin/indep-32/eamio.dll \
 		build/bin/indep-32/geninput.dll \
 		dist/ddr/config.bat \
+		dist/ddr/gamestart-17.bat \
+		dist/ddr/gamestart-18.bat \
 		dist/ddr/gamestart-14.bat \
 		dist/ddr/gamestart-15.bat \
 		dist/ddr/gamestart-16.bat \
@@ -728,6 +730,8 @@ $(zipdir)/ddr-16-to-18-x64.zip: \
 		build/bin/indep-64/eamio.dll \
 		build/bin/indep-64/geninput.dll \
 		dist/ddr/config.bat \
+		dist/ddr/gamestart-17.bat \
+		dist/ddr/gamestart-18.bat \
 		dist/ddr/gamestart-16.bat \
 		dist/ddr/gamestart-17.bat \
 		dist/ddr/gamestart-18.bat \

--- a/src/main/hook/table.c
+++ b/src/main/hook/table.c
@@ -15,7 +15,16 @@ static const size_t apiset_prefix_len = sizeof(apiset_prefix) - 1;
 static void hook_table_apply_to_all(
     const char *depname, const struct hook_symbol *syms, size_t nsyms);
 
+static void hook_table_revert_to_all(
+    const char *depname, const struct hook_symbol *syms, size_t nsyms);
+
 static void hook_table_apply_to_iid(
+    HMODULE target,
+    const pe_iid_t *iid,
+    const struct hook_symbol *syms,
+    size_t nsyms);
+
+static void hook_table_revert_to_iid(
     HMODULE target,
     const pe_iid_t *iid,
     const struct hook_symbol *syms,
@@ -41,6 +50,23 @@ static void hook_table_apply_to_all(
         }
 
         hook_table_apply(pe, depname, syms, nsyms);
+    }
+}
+
+static void hook_table_revert_to_all(
+    const char *depname, const struct hook_symbol *syms, size_t nsyms)
+{
+    const peb_dll_t *dll;
+    HMODULE pe;
+
+    for (dll = peb_dll_get_first(); dll != NULL; dll = peb_dll_get_next(dll)) {
+        pe = peb_dll_get_base(dll);
+
+        if (pe == NULL) {
+            continue; /* ?? Happens sometimes. */
+        }
+
+        hook_table_revert(pe, depname, syms, nsyms);
     }
 }
 
@@ -73,6 +99,35 @@ void hook_table_apply(
     }
 }
 
+void hook_table_revert(
+    HMODULE target,
+    const char *depname,
+    const struct hook_symbol *syms,
+    size_t nsyms)
+{
+    const pe_iid_t *iid;
+    const char *iid_name;
+
+    assert(depname != NULL);
+    assert(syms != NULL || nsyms == 0);
+
+    if (target == NULL) {
+        /*  Call out, which will then call us back repeatedly. Awkward, but
+            viewed from the outside it's good for usability. */
+
+        hook_table_revert_to_all(depname, syms, nsyms);
+    } else {
+        for (iid = pe_iid_get_first(target); iid != NULL;
+             iid = pe_iid_get_next(target, iid)) {
+            iid_name = pe_iid_get_name(target, iid);
+
+            if (hook_table_match_module(target, iid_name, depname)) {
+                hook_table_revert_to_iid(target, iid, syms, nsyms);
+            }
+        }
+    }
+}
+
 static void hook_table_apply_to_iid(
     HMODULE target,
     const pe_iid_t *iid,
@@ -96,6 +151,33 @@ static void hook_table_apply_to_iid(
                 }
 
                 pe_patch(iate.ppointer, &sym->patch, sizeof(sym->patch));
+            }
+        }
+    }
+}
+
+static void hook_table_revert_to_iid(
+    HMODULE target,
+    const pe_iid_t *iid,
+    const struct hook_symbol *syms,
+    size_t nsyms)
+{
+    struct pe_iat_entry iate;
+    size_t i;
+    size_t j;
+    const struct hook_symbol *sym;
+
+    i = 0;
+
+    while (pe_iid_get_iat_entry(target, iid, i++, &iate) == S_OK) {
+        for (j = 0; j < nsyms; j++) {
+            sym = &syms[j];
+
+            if (hook_table_match_proc(&iate, sym)) {
+                // Only revert-able if the original pointer was stored previously
+                if (sym->link != NULL && *sym->link != NULL) {
+                    pe_patch(iate.ppointer, sym->link, sizeof(*sym->link));
+                } 
             }
         }
     }


### PR DESCRIPTION
fix(hook): Add missing hook_table_revert impl

Allow hooks to cleanup when they are shut down.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/djhackersdev/bemanitools/pull/286).
* #298
* #297
* #296
* #295
* #294
* #293
* #292
* #291
* #290
* #289
* #288
* #287
* __->__ #286
* #285