### PR TITLE
feat(avs-util): Add helper to translate property errors

### DIFF
--- a/src/imports/avs.h
+++ b/src/imports/avs.h
@@ -221,7 +221,7 @@ int property_set_flag(struct property *prop, int flags, int mask);
 void property_destroy(struct property *prop);
 
 avs_error property_get_error(struct property *prop);
-struct property *property_clear_error(struct property *prop);
+void property_clear_error(struct property *prop);
 
 int property_psmap_import(
     struct property *prop,

--- a/src/main/avs-util/error.c
+++ b/src/main/avs-util/error.c
@@ -97,3 +97,13 @@ const char *avs_util_error_str(avs_error error)
 
     return avs_util_error_unknown;
 }
+
+const char *avs_util_property_error_get_and_clear(struct property *prop)
+{
+    avs_error error;
+
+    error = property_get_error(prop);
+    property_clear_error(prop);
+
+    return avs_util_error_str(error);
+}

--- a/src/main/avs-util/error.h
+++ b/src/main/avs-util/error.h
@@ -5,4 +5,6 @@
 
 const char *avs_util_error_str(avs_error error);
 
+const char *avs_util_property_error_get_and_clear(struct property *prop);
+
 #endif


### PR DESCRIPTION
feat(avs-util): Add helper to translate property errors

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/djhackersdev/bemanitools/pull/289).
* __->__ #289
* #299
* #288
* #287
* #286
* #285