### PR TITLE
fix(avs): Incorrect function signature

### DIFF
--- a/src/imports/avs.h
+++ b/src/imports/avs.h
@@ -221,7 +221,7 @@ int property_set_flag(struct property *prop, int flags, int mask);
 void property_destroy(struct property *prop);
 
 avs_error property_get_error(struct property *prop);
-struct property *property_clear_error(struct property *prop);
+void property_clear_error(struct property *prop);
 
 int property_psmap_import(
     struct property *prop,


### PR DESCRIPTION
fix(avs): Incorrect function signature


After getting doubts, I looked this one up again on the
assembly. The decompiled output confused me
and no actual value is being returned there.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/djhackersdev/bemanitools/pull/299).
* __->__ #299
* #288
* #287
* #286
* #285