### PR TITLE
feat: Bump iidxhook9 supported versions, EPOLIS “support"

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -431,7 +431,7 @@ $(zipdir)/iidx-25-to-26.zip: \
 	$(V)echo ... $@
 	$(V)zip -j $@ $^
 
-$(zipdir)/iidx-27-to-30.zip: \
+$(zipdir)/iidx-27-to-31.zip: \
 		build/bin/avs2_1700-64/iidxhook9.dll \
 		build/bin/avs2_1700-64/launcher.exe \
 		build/bin/indep-64/config.exe \
@@ -444,10 +444,12 @@ $(zipdir)/iidx-27-to-30.zip: \
 		dist/iidx/gamestart-28.bat \
 		dist/iidx/gamestart-29.bat \
 		dist/iidx/gamestart-30.bat \
+		dist/iidx/gamestart-31.bat \
 		dist/iidx/iidxhook-27.conf \
 		dist/iidx/iidxhook-28.conf \
 		dist/iidx/iidxhook-29.conf \
 		dist/iidx/iidxhook-30.conf \
+		dist/iidx/iidxhook-31.conf \
 		dist/iidx/vefx.txt \
 		| $(zipdir)/
 	$(V)echo ... $@
@@ -847,7 +849,7 @@ $(BUILDDIR)/bemanitools.zip: \
 		$(zipdir)/iidx-20-cn.zip \
 		$(zipdir)/iidx-21-to-24.zip \
 		$(zipdir)/iidx-25-to-26.zip \
-		$(zipdir)/iidx-27-to-30.zip \
+		$(zipdir)/iidx-27-to-31.zip \
 		$(zipdir)/iidx-hwio-x86.zip \
 		$(zipdir)/iidx-hwio-x64.zip \
 		$(zipdir)/jb-01.zip \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The following games are supported with their corresponding hook-libraries.
   - Beatmania IIDX 28 BISTROVER (`iidx-27-to-30.zip`): [iidxhook9](doc/iidxhook/iidxhook9.md)
   - Beatmania IIDX 29 CASTHOUR (`iidx-27-to-30.zip`): [iidxhook9](doc/iidxhook/iidxhook9.md)
   - Beatmania IIDX 30 RESIDENT (`iidx-27-to-30.zip`): [iidxhook9](doc/iidxhook/iidxhook9.md)
+  - Beatmania IIDX 31 EPOLIS (`iidx-27-to-31.zip`): [iidxhook9](doc/iidxhook/iidxhook9.md)
 - [jubeat](doc/jbhook/README.md)
   - jubeat (`jb-01.zip`): [jbhook1](doc/jbhook/jbhook1.md)
   - jubeat ripples (`jb-02.zip`): [jbhook1](doc/jbhook/jbhook1.md)

--- a/dist/iidx/gamestart-31.bat
+++ b/dist/iidx/gamestart-31.bat
@@ -1,0 +1,16 @@
+@echo off
+cd /d %~dp0
+
+if not exist dev mkdir dev
+if not exist dev\e mkdir dev\e
+if not exist dev\g mkdir dev\g
+if not exist dev\nvram mkdir dev\nvram
+if not exist dev\raw mkdir dev\raw
+if not exist dev\raw\log mkdir dev\raw\log
+if not exist dev\raw\fscache mkdir dev\raw\fscache
+
+for /R prop\defaults %%D in (*.*) do (
+    if not exist dev\nvram\%%~nxD copy /y prop\defaults\%%~nxD dev\nvram
+)
+
+modules\launcher -H 134217728 -B iidxhook9.dll bm2dx.dll --config iidxhook-31.conf %*

--- a/dist/iidx/iidxhook-31.conf
+++ b/dist/iidx/iidxhook-31.conf
@@ -1,0 +1,84 @@
+# Disable card reader emulation and enable usage of real card reader hardware on COM1 (for games supporting slotted readers)
+io.disable_card_reader_emu=false
+
+# Disable BIO2 emulation and enable usage of real BIO2 hardware
+io.disable_bio2_emu=false
+
+# Disables the poll limiter, warning very high CPU usage may arise
+io.disable_poll_limiter=false
+
+# Lightning cab mode (requires additional IO emulation)
+io.lightning_mode=false
+
+# Disable camera connection
+io.disable_cams=true
+
+# Disables the built in file hooks, requiring manual file creation
+io.disable_file_hooks=false
+
+# Turntable sensitivity multiplier (1.0 is default)
+io.tt_multiplier=1.0
+
+# Disables the camera emulation
+cam.disable_emu=true
+
+# Disable camera 1. Use, i.e., if you only have one camera and want it to be mapped to camera 2 ingame.
+cam.disable_camera1=true
+
+# Disable camera 2. Use, i.e., if you have more than one camera but only want to map camera 1 ingame.
+cam.disable_camera2=false
+
+# Override camera device ID detection (copy from device manager, do not escape)
+cam.device_id1=
+
+# Override camera device ID detection (copy from device manager, do not escape)
+cam.device_id2=
+
+# Run the game in a framed window (requires windowed option)
+gfx.framed=true
+
+# Run the game windowed
+gfx.windowed=false
+
+# Confine mouse cursor to window
+gfx.confined=false
+
+# Windowed width, -1 for default size
+gfx.window_width=-1
+
+# Windowed height, -1 for default size
+gfx.window_height=-1
+
+# Windowed X, -1 for default X position
+gfx.window_x=-1
+
+# Windowed Y, -1 for default Y position
+gfx.window_y=-1
+
+# Forced refresh rate, -1 to not force any (try 59 or 60 if monitor check fails to lock on high refresh rate monitors)
+gfx.forced_refresh_rate=-1
+
+# D3D9ex device adapter (monitor), -1 to use default, 0, 1, 2 etc. to use specified adapter
+gfx.device_adapter=-1
+
+# Orientation to force monitor into, -1 to use default, 0, 1, 2, 3 to do 0, 90, 180, 270 degrees
+gfx.force_orientation=-1
+
+# Force a screen resolution (width), -1 to disable. Use this if the game does not auto detect your monitor's resolution properly, e.g. 1368x768 instead of 1280x720.
+gfx.force_screen_res.width=-1
+
+# Force a screen resolution (height), -1 to disable. Use this if the game does not auto detect your monitor's resolution properly, e.g. 1368x768 instead of 1280x720.
+gfx.force_screen_res.height=-1
+
+# IP of adapter to force override with
+adapter.override_ip=
+
+# Force ASIO audio mode/device (if applicable / TDJ default)
+asio.force_asio=false
+
+# Force WASAPI audio mode (if applicable / LDJ default)
+asio.force_wasapi=true
+
+# The ASIO device name to use
+asio.device_name=XONAR SOUND CARD(64)
+

--- a/doc/iidxhook/iidxhook9.md
+++ b/doc/iidxhook/iidxhook9.md
@@ -6,6 +6,7 @@ The following games are compatible with this version of iidxhook:
 - BISTROVER
 - CASTHOUR
 - RESIDENT
+- EPOLIS
 
 The games must be bootstrapped using [launcher](../launcher.md).
 
@@ -57,7 +58,7 @@ unpacked data looks like this:
   - Unpack the package containing iidxhook9 into the root folder so iidxhook9.dll and all other
     files are located in the same folder as *data*, *prop*, *bm2dx.dll*, etc.
 
-- For version 30
+- For version 30-31
 
   - Unpack the package containing iidxhook9 into the `modules` folder so iidxhook9.dll and all other
     files are located in the same folder as the game's DLLs, e.g. *bm2dx.dll*, etc.


### PR DESCRIPTION

No changes required, just make support visible by reflecting
it in distribution package naming, documentation and
filenaming
