### PR TITLE
Work around reverb issue from 26100.3476

### DIFF
--- a/src/main/iidxhook9/Module.mk
+++ b/src/main/iidxhook9/Module.mk
@@ -30,4 +30,5 @@ libs_iidxhook9      := \
 src_iidxhook9       := \
     config-io.c \
     fs-hook.c \
+    reverbfix.c \
     dllmain.c \

--- a/src/main/iidxhook9/dllmain.c
+++ b/src/main/iidxhook9/dllmain.c
@@ -27,6 +27,7 @@
 
 #include "iidxhook9/config-io.h"
 #include "iidxhook9/fs-hook.h"
+#include "iidxhook9/reverbfix.h"
 
 #include "camhook/cam.h"
 #include "camhook/config-cam.h"
@@ -164,6 +165,8 @@ static bool my_dll_entry_init(char *sidcode, struct property_node *param)
         // redirect F:\ drive to vfs (used for video recording)
         iidxhook9_fs_hooks_init();
     }
+
+    reverbfixhook_init();
 
     rs232_hook_init();
     rs232_hook_limit_hooks();

--- a/src/main/iidxhook9/fs-hook.c
+++ b/src/main/iidxhook9/fs-hook.c
@@ -34,6 +34,15 @@ static void *my_avs_fs_mount(const char *dest, const char *src, const char *fs_t
 
         return real_avs_fs_mount(dest, dev_folder_drive, fs_type, options);
     }
+    if (src[0] == 'e' && src[1] == ':' && src[2] == '/' && src[3] == '\0') {
+        const char* dev_folder_drive = "dev/vfs/drive_e/";
+        log_misc("Redirecting %s to %s", src, dev_folder_drive);
+
+        CreateDirectoryA("dev/vfs/", NULL);
+        CreateDirectoryA("dev/vfs/drive_e/", NULL);
+
+        return real_avs_fs_mount(dest, dev_folder_drive, fs_type, options);
+    }
 
     return real_avs_fs_mount(dest, src, fs_type, options);
 }

--- a/src/main/iidxhook9/reverbfix.c
+++ b/src/main/iidxhook9/reverbfix.c
@@ -1,0 +1,56 @@
+#define LOG_MODULE "reverbfix-hook"
+
+// clang-format off
+// Don't format because the order is important here
+#include <windows.h>
+#include <initguid.h>
+// clang-format on
+
+#include <combaseapi.h>
+
+#include <stdio.h>
+
+#include "hook/com-proxy.h"
+#include "hook/table.h"
+
+#include "iidxhook9/reverbfix.h"
+
+#include "util/log.h"
+
+DEFINE_GUID(GUID_DSFX_STANDARD_I3DL2REVERB, 0xEF985E71,0xD5C7,0x42D4,0xBA,0x4D,0x2D,0x07,0x3E,0x2E,0x96,0xF4);
+DEFINE_GUID(GUID_DSFX_WAVES_REVERB,         0x87FC0268,0x9A55,0x4360,0x95,0xAA,0x00,0x4A,0x1D,0x9D,0xE2,0x6C);
+
+static HRESULT my_CoCreateInstance(
+    REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFIID riid, LPVOID *ppv);
+
+static HRESULT (*real_CoCreateInstance)(
+    REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFIID riid, LPVOID *ppv);
+
+static const struct hook_symbol reverbfix_ole_syms[] = {
+    {.name = "CoCreateInstance",
+     .patch = my_CoCreateInstance,
+     .link = (void **) &real_CoCreateInstance},
+};
+
+static HRESULT my_CoCreateInstance(
+    REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFIID riid, LPVOID *ppv)
+{
+    HRESULT result = real_CoCreateInstance(rclsid, pUnkOuter, dwClsContext, riid, ppv);
+    if (result == REGDB_E_CLASSNOTREG) {
+        if (IsEqualGUID(rclsid, &GUID_DSFX_STANDARD_I3DL2REVERB)) {
+            // replace effect used by REVERB EX with REVERB, based on CDmoSoundFx classes
+            result = real_CoCreateInstance(&GUID_DSFX_WAVES_REVERB, pUnkOuter, dwClsContext, riid, ppv);
+
+            log_info("DSFX_STANDARD_I3DL2REVERB class missing, replaced with DSFX_WAVES_REVERB");
+        }
+    }
+
+    return result;
+}
+
+void reverbfixhook_init()
+{
+    hook_table_apply(
+        NULL, "Ole32.dll", reverbfix_ole_syms, lengthof(reverbfix_ole_syms));
+    log_info("Inserted reverbfix hook");
+}

--- a/src/main/iidxhook9/reverbfix.h
+++ b/src/main/iidxhook9/reverbfix.h
@@ -1,0 +1,6 @@
+#ifndef REVERBFIXHOOK_H
+#define REVERBFIXHOOK_H
+
+void reverbfixhook_init();
+
+#endif


### PR DESCRIPTION
As per https://www.un4seen.com/forum/?topic=20654.0 people have noted that I3DL2REVERB is no longer available in Windows 11 which is used by REVERB EX.

This works around the issue by replacing it with WAVES_REVERB which is used by standard REVERB.

Also adds in E drive redirecting to the fshook.